### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,17 +25,17 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "kronos-adapter-inbound-file": "^1.0.0",
-    "kronos-adapter-inbound-http": "^1.0.0",
-    "kronos-adapter-outbound-file": "^1.0.0",
-    "kronos-step": "^1.1.0",
-    "kronos-step-data-processor-csv": "^1.2.0",
-    "kronos-step-gzip": "^1.0.0",
-    "stream-line-header": "^1.0.2",
-    "stream-line-parser": "^1.0.0",
-    "stream-line-tokenizer-csv": "^1.0.0",
-    "stream-line-tokens2obj": "^1.0.1",
-    "stream-object-data-processor-chunk": "^1.0.0",
-    "stream-object-data-processor-row": "^1.0.0"
+    "kronos-adapter-inbound-file": "1.0.0",
+    "kronos-adapter-inbound-http": "1.0.0",
+    "kronos-adapter-outbound-file": "1.0.0",
+    "kronos-step": "1.1.0",
+    "kronos-step-data-processor-csv": "1.2.0",
+    "kronos-step-gzip": "1.0.0",
+    "stream-line-header": "1.0.2",
+    "stream-line-parser": "1.0.0",
+    "stream-line-tokenizer-csv": "1.0.0",
+    "stream-line-tokens2obj": "1.0.1",
+    "stream-object-data-processor-chunk": "1.0.0",
+    "stream-object-data-processor-row": "1.0.0"
   }
 }


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:
- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/) – they’re always in a state you know about.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
